### PR TITLE
Fix Numeric field

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,11 @@
             "name": "Tomáš Prokop",
             "homepage": "https://github.com/naril",
             "role": "Developer"
+        },
+        {
+            "name": "Király Bálint",
+            "homepage": "https://github.com/kiralybalint",
+            "role": "Developer"
         }
     ],
     "minimum-stability": "stable",

--- a/src/field/NumericField.php
+++ b/src/field/NumericField.php
@@ -30,10 +30,10 @@ class NumericField extends Field {
      */
     public function toData($value) {
         if (is_null($value)) {
-            return "";
+            return sprintf('%'. $this->getLength().'s', '');
         } else {
             $value = number_format((float) $value, $this->getDecimalCount(), '.', '');
-            return substr(strval($value), 0, $this->getLength());
+            return str_pad(substr(strval($value), 0, $this->getLength()), $this->length, ' ', STR_PAD_LEFT);
         }
     }
 

--- a/tests/unit/field/NumericFieldTest.php
+++ b/tests/unit/field/NumericFieldTest.php
@@ -38,7 +38,8 @@ class NumericFieldTest extends AbstractFieldTest {
             array('1234', 123),
             array('123', 123),
             array(123, 123),
-            array(' 2', 2),
+            array('  2', 2),
+            array('2', 2),
             array(null, 0),
         );
     }
@@ -49,10 +50,10 @@ class NumericFieldTest extends AbstractFieldTest {
     public function dataToData() {
         return array(
             array(123456, '123'),
-            array(1,      '1'),
-            array(null,   ''),
-            array(false,  '0'),
-            array('',     '0'),
+            array(1,      '  1'),
+            array(null,   '   '),
+            array(false,  '  0'),
+            array('',     '  0'),
         );
     }
 


### PR DESCRIPTION
The dbase.com say:
"Number stored as a string, **right justified, and padded with blanks to the width of the field.**"
 http://www.dbase.com/Knowledgebase/INT/db7_file_fmt.htm
I interpreted that the 100 should be stored as ' 100' in the 4 long numeric fields.