### PR TITLE
NumericField: cast number_format param to float

### DIFF
--- a/src/field/NumericField.php
+++ b/src/field/NumericField.php
@@ -44,7 +44,7 @@ class NumericField extends Field {
         if (!$this->getDecimalCount()) {
             return (integer)substr($data, 0, $this->getLength());
         } else {
-            return (float)number_format(substr($data, 0, $this->getLength()), $this->getDecimalCount(), '.', '');
+            return (float)number_format((float)substr($data, 0, $this->getLength()), $this->getDecimalCount(), '.', '');
         }
     }
 


### PR DESCRIPTION
This will help to avoid an ErrorException: 
number_format() expects parameter 1 to be float, string given